### PR TITLE
Add Card CTA Carousel block

### DIFF
--- a/application/blocks/card_cta_carousel/add.php
+++ b/application/blocks/card_cta_carousel/add.php
@@ -1,0 +1,3 @@
+<?php defined('C5_EXECUTE') or die('Access Denied.');
+$this->inc('form_setup_html.php');
+?>

--- a/application/blocks/card_cta_carousel/controller.php
+++ b/application/blocks/card_cta_carousel/controller.php
@@ -1,0 +1,133 @@
+<?php
+namespace Application\Block\CardCtaCarousel;
+
+use Concrete\Core\Block\BlockController;
+use Concrete\Core\Editor\LinkAbstractor;
+use Concrete\Core\Page\Page;
+use Concrete\Core\File\File;
+
+class Controller extends BlockController
+{
+    protected $btTable = 'btCardCtaCarousel';
+    protected $btExportTables = ['btCardCtaCarousel', 'btCardCtaCarouselCards'];
+    protected $btInterfaceWidth = 600;
+    protected $btInterfaceHeight = 550;
+    protected $btWrapperClass = 'ccm-ui';
+    protected $btCacheBlockOutput = true;
+    protected $btCacheBlockOutputOnPost = true;
+    protected $btCacheBlockOutputForRegisteredUsers = true;
+
+    public function getBlockTypeDescription()
+    {
+        return t('Carousel of cards with optional call to action.');
+    }
+
+    public function getBlockTypeName()
+    {
+        return t('Card CTA Carousel');
+    }
+
+    public function add()
+    {
+        $this->requireAsset('core/file-manager');
+        $this->requireAsset('core/sitemap');
+    }
+
+    public function edit()
+    {
+        $this->requireAsset('core/file-manager');
+        $this->requireAsset('core/sitemap');
+        $db = $this->app->make('database')->connection();
+        $rows = $db->fetchAll('SELECT * FROM btCardCtaCarouselCards WHERE bID = ? ORDER BY sortOrder', [$this->bID]);
+        $this->set('rows', $rows);
+    }
+
+    public function view()
+    {
+        $db = $this->app->make('database')->connection();
+        $rows = $db->fetchAll('SELECT * FROM btCardCtaCarouselCards WHERE bID = ? ORDER BY sortOrder', [$this->bID]);
+        foreach ($rows as &$row) {
+            $row['description'] = LinkAbstractor::translateFrom($row['description']);
+            switch ((int)$row['linkType']) {
+                case 1:
+                    if ($row['internalLinkCID']) {
+                        $page = Page::getByID($row['internalLinkCID']);
+                        if (is_object($page) && !$page->isError()) {
+                            $row['linkURL'] = $page->getCollectionLink();
+                        }
+                    }
+                    break;
+                case 3:
+                    if ($row['fileLinkFID']) {
+                        $f = File::getByID($row['fileLinkFID']);
+                        if (is_object($f)) {
+                            $row['linkURL'] = $f->getDownloadURL();
+                        }
+                    }
+                    break;
+            }
+        }
+        $this->set('rows', $rows);
+    }
+
+    public function duplicate($newBID)
+    {
+        $db = $this->app->make('database')->connection();
+        $rows = $db->fetchAll('SELECT * FROM btCardCtaCarouselCards WHERE bID = ?', [$this->bID]);
+        foreach ($rows as $row) {
+            $db->insert('btCardCtaCarouselCards', [
+                'bID' => $newBID,
+                'iconFID' => $row['iconFID'],
+                'title' => $row['title'],
+                'description' => $row['description'],
+                'linkType' => $row['linkType'],
+                'linkURL' => $row['linkURL'],
+                'internalLinkCID' => $row['internalLinkCID'],
+                'fileLinkFID' => $row['fileLinkFID'],
+                'sortOrder' => $row['sortOrder'],
+            ]);
+        }
+    }
+
+    public function delete()
+    {
+        $db = $this->app->make('database')->connection();
+        $db->delete('btCardCtaCarouselCards', ['bID' => $this->bID]);
+        parent::delete();
+    }
+
+    public function save($args)
+    {
+        $db = $this->app->make('database')->connection();
+        $db->delete('btCardCtaCarouselCards', ['bID' => $this->bID]);
+        parent::save($args);
+        if (isset($args['title']) && is_array($args['title'])) {
+            $count = count($args['title']);
+            for ($i = 0; $i < $count; $i++) {
+                $desc = isset($args['description'][$i]) ? LinkAbstractor::translateTo($args['description'][$i]) : '';
+                $db->insert('btCardCtaCarouselCards', [
+                    'bID' => $this->bID,
+                    'iconFID' => intval($args['iconFID'][$i]),
+                    'title' => $args['title'][$i],
+                    'description' => $desc,
+                    'linkType' => intval($args['linkType'][$i]),
+                    'linkURL' => $args['linkURL'][$i],
+                    'internalLinkCID' => intval($args['internalLinkCID'][$i]),
+                    'fileLinkFID' => intval($args['fileLinkFID'][$i]),
+                    'sortOrder' => intval($args['sortOrder'][$i]),
+                ]);
+            }
+        }
+    }
+
+    public function getSearchableContent()
+    {
+        $db = $this->app->make('database')->connection();
+        $rows = $db->fetchAll('SELECT * FROM btCardCtaCarouselCards WHERE bID = ? ORDER BY sortOrder', [$this->bID]);
+        $content = '';
+        foreach ($rows as $row) {
+            $content .= $row['title'] . ' ' . $row['description'] . ' ';
+        }
+        return $content;
+    }
+}

--- a/application/blocks/card_cta_carousel/db.xml
+++ b/application/blocks/card_cta_carousel/db.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<schema xmlns="http://www.concrete5.org/doctrine-xml/0.5"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://www.concrete5.org/doctrine-xml/0.5 http://concrete5.github.io/doctrine-xml/doctrine-xml-0.5.xsd">
+    <table name="btCardCtaCarousel">
+        <field name="bID" type="integer">
+            <unsigned/>
+            <key/>
+        </field>
+    </table>
+    <table name="btCardCtaCarouselCards">
+        <field name="id" type="integer">
+            <unsigned/>
+            <autoincrement/>
+            <key/>
+        </field>
+        <field name="bID" type="integer">
+            <unsigned/>
+        </field>
+        <field name="iconFID" type="integer">
+            <unsigned/>
+            <default value="0"/>
+        </field>
+        <field name="title" type="string" size="255"/>
+        <field name="description" type="text"/>
+        <field name="linkType" type="integer">
+            <unsigned/>
+            <default value="0"/>
+        </field>
+        <field name="linkURL" type="string" size="255"/>
+        <field name="internalLinkCID" type="integer">
+            <unsigned/>
+            <default value="0"/>
+        </field>
+        <field name="fileLinkFID" type="integer">
+            <unsigned/>
+            <default value="0"/>
+        </field>
+        <field name="sortOrder" type="integer"/>
+        <index name="bID">
+            <col>bID</col>
+            <col>sortOrder</col>
+        </index>
+    </table>
+</schema>

--- a/application/blocks/card_cta_carousel/edit.php
+++ b/application/blocks/card_cta_carousel/edit.php
@@ -1,0 +1,3 @@
+<?php defined('C5_EXECUTE') or die('Access Denied.');
+$this->inc('form_setup_html.php');
+?>

--- a/application/blocks/card_cta_carousel/form_setup_html.php
+++ b/application/blocks/card_cta_carousel/form_setup_html.php
@@ -1,0 +1,185 @@
+<?php defined('C5_EXECUTE') or die('Access Denied.'); ?>
+<style>
+    .ccm-card-carousel-container .btn-success { margin-bottom:20px; }
+    .ccm-card-entry { position:relative; }
+    .ccm-card-entry.well { margin-bottom:10px; padding:28px 10px 10px; }
+    .ccm-card-entry.entry-closed { height:57px; padding:0 0 0 15px; }
+    .ccm-card-entry.entry-closed .entry-collapse-text { display:block; line-height:57px; overflow:hidden; text-overflow:ellipsis; white-space:nowrap; width:335px; }
+    .ccm-card-entry.entry-closed .form-group { display:none; }
+    .ccm-card-entry .form-group:last-of-type { margin-bottom:0; }
+    .ccm-edit-entry { position:absolute; right:127px; top:10px; }
+    .ccm-delete-card-entry { position:absolute; right:41px; top:10px; }
+    .ccm-card-carousel-container i.fa-arrows { cursor:move; font-size:20px; padding:5px; position:absolute; right:5px; top:6px; }
+    .ccm-card-carousel-container .ui-state-highlight { height:57px; margin-bottom:10px; }
+</style>
+<div class="ccm-card-carousel-container">
+    <button type="button" class="btn btn-success ccm-add-card-entry"><?=t('Add Card')?></button>
+    <?php if (isset($rows) && count($rows)) { foreach ($rows as $row) { ?>
+        <div class="ccm-card-entry well entry-closed">
+            <p class="entry-collapse-text"><?php echo h($row['title']); ?></p>
+            <div class="form-group">
+                <label class="control-label"><?=t('Icon')?></label>
+                <div class="ccm-pick-icon">
+                    <?php if ($row['iconFID']) { $f=File::getByID($row['iconFID']); if ($f) { echo $f->getThumbnailTag('file_manager_listing'); } } ?>
+                </div>
+                <input type="hidden" name="iconFID[]" class="icon-fid" value="<?php echo intval($row['iconFID']); ?>">
+            </div>
+            <div class="form-group">
+                <label class="control-label"><?=t('Title')?></label>
+                <input class="form-control" type="text" name="title[]" value="<?php echo h($row['title']); ?>">
+            </div>
+            <div class="form-group">
+                <label class="control-label"><?=t('Description')?></label>
+                <textarea class="editor-content" name="description[]"><?php echo LinkAbstractor::translateFromEditMode($row['description']); ?></textarea>
+            </div>
+            <div class="form-group">
+                <label class="control-label"><?=t('Link Type')?></label>
+                <select data-field="entry-link-type" name="linkType[]" class="form-control">
+                    <option value="0" <?php if ((int)$row['linkType']===0) echo 'selected'; ?>><?=t('None')?></option>
+                    <option value="1" <?php if ((int)$row['linkType']===1) echo 'selected'; ?>><?=t('Internal Page')?></option>
+                    <option value="2" <?php if ((int)$row['linkType']===2) echo 'selected'; ?>><?=t('External URL')?></option>
+                    <option value="3" <?php if ((int)$row['linkType']===3) echo 'selected'; ?>><?=t('File')?></option>
+                </select>
+            </div>
+            <div data-link-type="1" class="form-group link-field link-field-1">
+                <label class="control-label"><?=t('Choose Page:')?></label>
+                <div data-field="page-selector"></div>
+            </div>
+            <div data-link-type="2" class="form-group link-field link-field-2">
+                <label class="control-label"><?=t('URL')?></label>
+                <input type="text" name="linkURL[]" class="form-control" value="<?php echo h($row['linkURL']); ?>">
+            </div>
+            <div data-link-type="3" class="form-group link-field link-field-3">
+                <label class="control-label"><?=t('File')?></label>
+                <div class="ccm-pick-link-file">
+                    <?php if ($row['fileLinkFID']) { $lf=File::getByID($row['fileLinkFID']); if ($lf) { echo $lf->getThumbnailTag('file_manager_listing'); } } ?>
+                </div>
+                <input type="hidden" name="fileLinkFID[]" class="file-link-fid" value="<?php echo intval($row['fileLinkFID']); ?>">
+            </div>
+            <button type="button" class="btn btn-sm btn-default ccm-edit-entry" data-entry-close-text="<?=t('Collapse Card')?>" data-entry-edit-text="<?=t('Edit Card')?>"><?=t('Edit Card')?></button>
+            <button type="button" class="btn btn-sm btn-danger ccm-delete-card-entry"><?=t('Remove')?></button>
+            <i class="fa fa-arrows"></i>
+            <input class="ccm-card-entry-sort" type="hidden" name="sortOrder[]" value="<?php echo intval($row['sortOrder']); ?>">
+        </div>
+    <?php } } else { ?>
+        <script>_.defer(function(){ $('.ccm-add-card-entry').click(); });</script>
+    <?php } ?>
+    <div class="ccm-card-entry well ccm-card-entry-template" style="display:none;">
+        <p class="entry-collapse-text"></p>
+        <div class="form-group">
+            <label class="control-label"><?=t('Icon')?></label>
+            <div class="ccm-pick-icon"></div>
+            <input type="hidden" name="iconFID[]" class="icon-fid" value="">
+        </div>
+        <div class="form-group">
+            <label class="control-label"><?=t('Title')?></label>
+            <input class="form-control" type="text" name="title[]" value="">
+        </div>
+        <div class="form-group">
+            <label class="control-label"><?=t('Description')?></label>
+            <textarea class="editor-content" name="description[]"></textarea>
+        </div>
+        <div class="form-group">
+            <label class="control-label"><?=t('Link Type')?></label>
+            <select data-field="entry-link-type" name="linkType[]" class="form-control">
+                <option value="0"><?=t('None')?></option>
+                <option value="1"><?=t('Internal Page')?></option>
+                <option value="2"><?=t('External URL')?></option>
+                <option value="3"><?=t('File')?></option>
+            </select>
+        </div>
+        <div data-link-type="1" class="form-group link-field link-field-1">
+            <label class="control-label"><?=t('Choose Page:')?></label>
+            <div data-field="page-selector"></div>
+        </div>
+        <div data-link-type="2" class="form-group link-field link-field-2">
+            <label class="control-label"><?=t('URL')?></label>
+            <input type="text" name="linkURL[]" class="form-control" value="">
+        </div>
+        <div data-link-type="3" class="form-group link-field link-field-3">
+            <label class="control-label"><?=t('File')?></label>
+            <div class="ccm-pick-link-file"></div>
+            <input type="hidden" name="fileLinkFID[]" class="file-link-fid" value="">
+        </div>
+        <button type="button" class="btn btn-sm btn-default ccm-edit-entry" data-entry-close-text="<?=t('Collapse Card')?>" data-entry-edit-text="<?=t('Edit Card')?>"><?=t('Edit Card')?></button>
+        <button type="button" class="btn btn-sm btn-danger ccm-delete-card-entry"><?=t('Remove')?></button>
+        <i class="fa fa-arrows"></i>
+        <input class="ccm-card-entry-sort" type="hidden" name="sortOrder[]" value="">
+    </div>
+</div>
+<?php
+$editorJavascript = Core::make('editor')->outputStandardEditorInitJSFunction();
+?>
+<script>
+var launchEditor = <?=$editorJavascript?>;
+$(function(){
+    var container = $('.ccm-card-carousel-container');
+    function doSort(){
+        container.find('.ccm-card-entry').each(function(i){
+            $(this).find('.ccm-card-entry-sort').val(i);
+        });
+    }
+    function attach(entry){
+        entry.find('.ccm-delete-card-entry').click(function(){
+            if(confirm('<?=t('Are you sure?')?>')){
+                var id = entry.find('.editor-content').attr('id');
+                if (typeof CKEDITOR !== 'undefined' && CKEDITOR.instances[id]) {
+                    CKEDITOR.instances[id].destroy();
+                }
+                entry.remove();
+                doSort();
+            }
+        });
+        entry.find('.ccm-pick-icon').click(function(){
+            var holder = $(this);
+            ConcreteFileManager.launchDialog(function(data){
+                ConcreteFileManager.getFileDetails(data.fID, function(r){
+                    var file = r.files[0];
+                    holder.html(file.resultsThumbnailImg);
+                    holder.next('.icon-fid').val(file.fID);
+                });
+            });
+        });
+        entry.find('.ccm-pick-link-file').click(function(){
+            var holder = $(this);
+            ConcreteFileManager.launchDialog(function(data){
+                ConcreteFileManager.getFileDetails(data.fID, function(r){
+                    var file = r.files[0];
+                    holder.html(file.resultsThumbnailImg);
+                    holder.next('.file-link-fid').val(file.fID);
+                });
+            });
+        });
+        entry.find('div[data-field=page-selector]').concretePageSelector({inputName:'internalLinkCID[]'});
+        entry.find('select[data-field=entry-link-type]').change(function(){
+            var val = parseInt($(this).val());
+            entry.find('.link-field').hide();
+            entry.find('.link-field-' + val).show();
+        }).trigger('change');
+    }
+    var template = $('.ccm-card-entry-template').clone();
+    $('.ccm-card-entry-template').remove();
+    container.find('.ccm-card-entry').each(function(){
+        $(this).find('.editor-content').attr('id', _.uniqueId());
+        launchEditor($(this).find('.editor-content'));
+        attach($(this));
+    });
+    $('.ccm-add-card-entry').click(function(){
+        var newEntry = template.clone();
+        newEntry.removeClass('ccm-card-entry-template').addClass('ccm-card-entry');
+        newEntry.find('.editor-content').attr('id', _.uniqueId());
+        launchEditor(newEntry.find('.editor-content'));
+        container.append(newEntry);
+        attach(newEntry);
+        doSort();
+    });
+    container.sortable({
+        handle:'i.fa-arrows',
+        axis:'y',
+        cursor:'move',
+        placeholder:'ui-state-highlight',
+        update:doSort
+    });
+    doSort();
+});
+</script>

--- a/application/blocks/card_cta_carousel/view.css
+++ b/application/blocks/card_cta_carousel/view.css
@@ -1,0 +1,11 @@
+.card-cta-carousel .card-cta-item{
+    text-align:center;
+    padding:15px;
+}
+.card-cta-carousel .card-cta-icon{
+    max-width:80px;
+    margin-bottom:10px;
+}
+.card-cta-carousel .card-cta-button{
+    margin-top:10px;
+}

--- a/application/blocks/card_cta_carousel/view.php
+++ b/application/blocks/card_cta_carousel/view.php
@@ -1,0 +1,44 @@
+<?php defined('C5_EXECUTE') or die('Access Denied.');
+$u = new User();
+?>
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/swiper@8/swiper-bundle.min.css" />
+<div class="swiper card-cta-carousel" id="card-cta-carousel-<?=$bID?>">
+    <div class="swiper-wrapper">
+        <?php foreach ($rows as $row) { ?>
+            <div class="swiper-slide">
+                <div class="card-cta-item">
+                    <?php if ($row['iconFID']) { $f = File::getByID($row['iconFID']); if ($f) { ?>
+                        <img class="card-cta-icon" src="<?= $f->getRelativePath() ?>" alt="" />
+                    <?php } } ?>
+                    <?php if ($row['title']) { ?>
+                        <h3 class="card-cta-title"><?= h($row['title']) ?></h3>
+                    <?php } ?>
+                    <div class="card-cta-description">
+                        <?= $row['description'] ?>
+                    </div>
+                    <?php if (!empty($row['linkURL'])) { ?>
+                        <div class="card-cta-button"><a href="<?= $row['linkURL'] ?>" class="btn btn-primary" target="_blank"><?= t('Learn More') ?></a></div>
+                    <?php } ?>
+                </div>
+            </div>
+        <?php } ?>
+    </div>
+    <div class="swiper-button-prev"></div>
+    <div class="swiper-button-next"></div>
+    <div class="swiper-pagination"></div>
+</div>
+<script src="https://cdn.jsdelivr.net/npm/swiper@8/swiper-bundle.min.js"></script>
+<script>
+var swiper = new Swiper('#card-cta-carousel-<?=$bID?>', {
+    loop: true,
+    navigation: {
+        nextEl: '#card-cta-carousel-<?=$bID?> .swiper-button-next',
+        prevEl: '#card-cta-carousel-<?=$bID?> .swiper-button-prev'
+    },
+    pagination: {
+        el: '#card-cta-carousel-<?=$bID?> .swiper-pagination',
+        clickable: true
+    }
+});
+</script>
+


### PR DESCRIPTION
## Summary
- add new `card_cta_carousel` block for card-based CTA slides
- implement controller, view, and form setup with SwiperJS front-end
- add database schema and styles

## Testing
- `vendor/bin/phpunit` *(fails: php not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68407cd7a3c0832da88e04f903342a3a