### PR TITLE
Add team member repeater block

### DIFF
--- a/application/blocks/team_member_repeater/add.php
+++ b/application/blocks/team_member_repeater/add.php
@@ -1,0 +1,2 @@
+<?php defined('C5_EXECUTE') or die('Access Denied.');
+$this->inc('form_setup_html.php');

--- a/application/blocks/team_member_repeater/controller.php
+++ b/application/blocks/team_member_repeater/controller.php
@@ -1,0 +1,105 @@
+<?php
+namespace Application\Block\TeamMemberRepeater;
+
+use Concrete\Core\Block\BlockController;
+use Concrete\Core\Editor\LinkAbstractor;
+use Concrete\Core\File\File;
+
+class Controller extends BlockController
+{
+    protected $btTable = 'btTeamMemberRepeater';
+    protected $btExportTables = ['btTeamMemberRepeater', 'btTeamMemberRepeaterMembers'];
+    protected $btInterfaceWidth = 600;
+    protected $btInterfaceHeight = 600;
+    protected $btWrapperClass = 'ccm-ui';
+    protected $btCacheBlockOutput = true;
+    protected $btCacheBlockOutputOnPost = true;
+    protected $btCacheBlockOutputForRegisteredUsers = true;
+
+    public function getBlockTypeName()
+    {
+        return t('Team Member Repeater');
+    }
+
+    public function getBlockTypeDescription()
+    {
+        return t('List team members with headshot and bio.');
+    }
+
+    public function add()
+    {
+        $this->requireAsset('core/file-manager');
+    }
+
+    public function edit()
+    {
+        $this->requireAsset('core/file-manager');
+        $db = $this->app->make('database')->connection();
+        $this->set('rows', $db->fetchAll('SELECT * FROM btTeamMemberRepeaterMembers WHERE bID = ? ORDER BY sortOrder', [$this->bID]));
+    }
+
+    public function view()
+    {
+        $db = $this->app->make('database')->connection();
+        $rows = $db->fetchAll('SELECT * FROM btTeamMemberRepeaterMembers WHERE bID = ? ORDER BY sortOrder', [$this->bID]);
+        foreach ($rows as &$row) {
+            $row['bio'] = LinkAbstractor::translateFrom($row['bio']);
+        }
+        $this->set('rows', $rows);
+    }
+
+    public function duplicate($newBID)
+    {
+        $db = $this->app->make('database')->connection();
+        $rows = $db->fetchAll('SELECT * FROM btTeamMemberRepeaterMembers WHERE bID = ?', [$this->bID]);
+        foreach ($rows as $row) {
+            $db->insert('btTeamMemberRepeaterMembers', [
+                'bID' => $newBID,
+                'firstName' => $row['firstName'],
+                'lastName' => $row['lastName'],
+                'headshotFID' => $row['headshotFID'],
+                'bio' => $row['bio'],
+                'sortOrder' => $row['sortOrder'],
+            ]);
+        }
+    }
+
+    public function delete()
+    {
+        $db = $this->app->make('database')->connection();
+        $db->delete('btTeamMemberRepeaterMembers', ['bID' => $this->bID]);
+        parent::delete();
+    }
+
+    public function save($args)
+    {
+        $db = $this->app->make('database')->connection();
+        $db->delete('btTeamMemberRepeaterMembers', ['bID' => $this->bID]);
+        parent::save($args);
+        if (isset($args['firstName']) && is_array($args['firstName'])) {
+            $count = count($args['firstName']);
+            for ($i = 0; $i < $count; $i++) {
+                $bio = isset($args['bio'][$i]) ? LinkAbstractor::translateTo($args['bio'][$i]) : '';
+                $db->insert('btTeamMemberRepeaterMembers', [
+                    'bID' => $this->bID,
+                    'firstName' => $args['firstName'][$i],
+                    'lastName' => $args['lastName'][$i],
+                    'headshotFID' => intval($args['headshotFID'][$i]),
+                    'bio' => $bio,
+                    'sortOrder' => intval($args['sortOrder'][$i]),
+                ]);
+            }
+        }
+    }
+
+    public function getSearchableContent()
+    {
+        $db = $this->app->make('database')->connection();
+        $rows = $db->fetchAll('SELECT * FROM btTeamMemberRepeaterMembers WHERE bID = ? ORDER BY sortOrder', [$this->bID]);
+        $content = '';
+        foreach ($rows as $row) {
+            $content .= $row['firstName'] . ' ' . $row['lastName'] . ' ' . $row['bio'] . ' ';
+        }
+        return $content;
+    }
+}

--- a/application/blocks/team_member_repeater/db.xml
+++ b/application/blocks/team_member_repeater/db.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<schema xmlns="http://www.concrete5.org/doctrine-xml/0.5"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://www.concrete5.org/doctrine-xml/0.5 http://concrete5.github.io/doctrine-xml/doctrine-xml-0.5.xsd">
+    <table name="btTeamMemberRepeater">
+        <field name="bID" type="integer">
+            <unsigned/>
+            <key/>
+        </field>
+        <field name="headerTitle" type="string" size="255" />
+        <field name="headerDescription" type="text" />
+        <field name="buttonOneText" type="string" size="255" />
+        <field name="buttonOneLink" type="string" size="255" />
+        <field name="buttonTwoText" type="string" size="255" />
+        <field name="buttonTwoLink" type="string" size="255" />
+    </table>
+    <table name="btTeamMemberRepeaterMembers">
+        <field name="id" type="integer">
+            <unsigned/>
+            <autoincrement/>
+            <key/>
+        </field>
+        <field name="bID" type="integer">
+            <unsigned/>
+        </field>
+        <field name="firstName" type="string" size="255" />
+        <field name="lastName" type="string" size="255" />
+        <field name="headshotFID" type="integer">
+            <unsigned/>
+            <default value="0"/>
+        </field>
+        <field name="bio" type="text" />
+        <field name="sortOrder" type="integer" />
+        <index name="bID">
+            <col>bID</col>
+            <col>sortOrder</col>
+        </index>
+    </table>
+</schema>

--- a/application/blocks/team_member_repeater/edit.php
+++ b/application/blocks/team_member_repeater/edit.php
@@ -1,0 +1,2 @@
+<?php defined('C5_EXECUTE') or die('Access Denied.');
+$this->inc('form_setup_html.php');

--- a/application/blocks/team_member_repeater/form_setup_html.php
+++ b/application/blocks/team_member_repeater/form_setup_html.php
@@ -1,0 +1,155 @@
+<?php defined('C5_EXECUTE') or die('Access Denied.'); ?>
+<style>
+    .ccm-team-container .btn-success { margin-bottom:20px; }
+    .ccm-team-entry { position:relative; }
+    .ccm-team-entry.well { margin-bottom:10px; padding:28px 10px 10px; }
+    .ccm-team-entry.entry-closed { height:57px; padding:0 0 0 15px; }
+    .ccm-team-entry.entry-closed .entry-collapse-text { display:block; line-height:57px; overflow:hidden; text-overflow:ellipsis; white-space:nowrap; width:335px; }
+    .ccm-team-entry.entry-closed .form-group { display:none; }
+    .ccm-team-entry .form-group:last-of-type { margin-bottom:0; }
+    .ccm-edit-entry { position:absolute; right:127px; top:10px; }
+    .ccm-delete-team-entry { position:absolute; right:41px; top:10px; }
+    .ccm-team-container i.fa-arrows { cursor:move; font-size:20px; padding:5px; position:absolute; right:5px; top:6px; }
+    .ccm-team-container .ui-state-highlight { height:57px; margin-bottom:10px; }
+</style>
+<div class="form-group">
+    <label class="control-label"><?=t('Header Title')?></label>
+    <input class="form-control" type="text" name="headerTitle" value="<?php echo h($headerTitle); ?>">
+</div>
+<div class="form-group">
+    <label class="control-label"><?=t('Header Description')?></label>
+    <textarea class="editor-content-header" name="headerDescription"><?php echo h($headerDescription); ?></textarea>
+</div>
+<div class="form-group">
+    <label class="control-label"><?=t('Button One Text')?></label>
+    <input class="form-control" type="text" name="buttonOneText" value="<?php echo h($buttonOneText); ?>">
+</div>
+<div class="form-group">
+    <label class="control-label"><?=t('Button One Link')?></label>
+    <input class="form-control" type="text" name="buttonOneLink" value="<?php echo h($buttonOneLink); ?>">
+</div>
+<div class="form-group">
+    <label class="control-label"><?=t('Button Two Text')?></label>
+    <input class="form-control" type="text" name="buttonTwoText" value="<?php echo h($buttonTwoText); ?>">
+</div>
+<div class="form-group">
+    <label class="control-label"><?=t('Button Two Link')?></label>
+    <input class="form-control" type="text" name="buttonTwoLink" value="<?php echo h($buttonTwoLink); ?>">
+</div>
+<div class="ccm-team-container">
+    <button type="button" class="btn btn-success ccm-add-team-entry"><?=t('Add Member')?></button>
+    <?php if (isset($rows) && count($rows)) { foreach ($rows as $row) { ?>
+        <div class="ccm-team-entry well entry-closed">
+            <p class="entry-collapse-text"><?php echo h($row['firstName'] . ' ' . $row['lastName']); ?></p>
+            <div class="form-group">
+                <label class="control-label"><?=t('First Name')?></label>
+                <input class="form-control" type="text" name="firstName[]" value="<?php echo h($row['firstName']); ?>">
+            </div>
+            <div class="form-group">
+                <label class="control-label"><?=t('Last Name')?></label>
+                <input class="form-control" type="text" name="lastName[]" value="<?php echo h($row['lastName']); ?>">
+            </div>
+            <div class="form-group">
+                <label class="control-label"><?=t('Headshot')?></label>
+                <div class="ccm-pick-headshot">
+                    <?php if ($row['headshotFID']) { $f=File::getByID($row['headshotFID']); if ($f) { echo $f->getThumbnailTag('file_manager_listing'); } } ?>
+                </div>
+                <input type="hidden" name="headshotFID[]" class="headshot-fid" value="<?php echo intval($row['headshotFID']); ?>">
+            </div>
+            <div class="form-group">
+                <label class="control-label"><?=t('Bio')?></label>
+                <textarea class="editor-content" name="bio[]"><?php echo LinkAbstractor::translateFromEditMode($row['bio']); ?></textarea>
+            </div>
+            <button type="button" class="btn btn-sm btn-default ccm-edit-entry" data-entry-close-text="<?=t('Collapse Member')?>" data-entry-edit-text="<?=t('Edit Member')?>"><?=t('Edit Member')?></button>
+            <button type="button" class="btn btn-sm btn-danger ccm-delete-team-entry"><?=t('Remove')?></button>
+            <i class="fa fa-arrows"></i>
+            <input class="ccm-team-entry-sort" type="hidden" name="sortOrder[]" value="<?php echo intval($row['sortOrder']); ?>">
+        </div>
+    <?php } } else { ?>
+        <script>_.defer(function(){ $('.ccm-add-team-entry').click(); });</script>
+    <?php } ?>
+    <div class="ccm-team-entry well ccm-team-entry-template" style="display:none;">
+        <p class="entry-collapse-text"></p>
+        <div class="form-group">
+            <label class="control-label"><?=t('First Name')?></label>
+            <input class="form-control" type="text" name="firstName[]" value="">
+        </div>
+        <div class="form-group">
+            <label class="control-label"><?=t('Last Name')?></label>
+            <input class="form-control" type="text" name="lastName[]" value="">
+        </div>
+        <div class="form-group">
+            <label class="control-label"><?=t('Headshot')?></label>
+            <div class="ccm-pick-headshot"></div>
+            <input type="hidden" name="headshotFID[]" class="headshot-fid" value="">
+        </div>
+        <div class="form-group">
+            <label class="control-label"><?=t('Bio')?></label>
+            <textarea class="editor-content" name="bio[]"></textarea>
+        </div>
+        <button type="button" class="btn btn-sm btn-default ccm-edit-entry" data-entry-close-text="<?=t('Collapse Member')?>" data-entry-edit-text="<?=t('Edit Member')?>"><?=t('Edit Member')?></button>
+        <button type="button" class="btn btn-sm btn-danger ccm-delete-team-entry"><?=t('Remove')?></button>
+        <i class="fa fa-arrows"></i>
+        <input class="ccm-team-entry-sort" type="hidden" name="sortOrder[]" value="">
+    </div>
+</div>
+<?php
+$editorJavascript = Core::make('editor')->outputStandardEditorInitJSFunction();
+?>
+<script>
+var launchEditor = <?=$editorJavascript?>;
+$(function(){
+    var container = $('.ccm-team-container');
+    function doSort(){
+        container.find('.ccm-team-entry').each(function(i){
+            $(this).find('.ccm-team-entry-sort').val(i);
+        });
+    }
+    function attach(entry){
+        entry.find('.ccm-delete-team-entry').click(function(){
+            if(confirm('<?=t('Are you sure?')?>')){
+                var id = entry.find('.editor-content').attr('id');
+                if (typeof CKEDITOR !== 'undefined' && CKEDITOR.instances[id]) {
+                    CKEDITOR.instances[id].destroy();
+                }
+                entry.remove();
+                doSort();
+            }
+        });
+        entry.find('.ccm-pick-headshot').click(function(){
+            var holder = $(this);
+            ConcreteFileManager.launchDialog(function(data){
+                ConcreteFileManager.getFileDetails(data.fID, function(r){
+                    var file = r.files[0];
+                    holder.html(file.resultsThumbnailImg);
+                    holder.next('.headshot-fid').val(file.fID);
+                });
+            });
+        });
+    }
+    var template = $('.ccm-team-entry-template').clone();
+    $('.ccm-team-entry-template').remove();
+    container.find('.ccm-team-entry').each(function(){
+        $(this).find('.editor-content').attr('id', _.uniqueId());
+        launchEditor($(this).find('.editor-content'));
+        attach($(this));
+    });
+    $('.ccm-add-team-entry').click(function(){
+        var newEntry = template.clone();
+        newEntry.removeClass('ccm-team-entry-template').addClass('ccm-team-entry');
+        newEntry.find('.editor-content').attr('id', _.uniqueId());
+        launchEditor(newEntry.find('.editor-content'));
+        container.append(newEntry);
+        attach(newEntry);
+        doSort();
+    });
+    container.sortable({
+        handle:'i.fa-arrows',
+        axis:'y',
+        cursor:'move',
+        placeholder:'ui-state-highlight',
+        update:doSort
+    });
+    doSort();
+});
+</script>

--- a/application/blocks/team_member_repeater/view.css
+++ b/application/blocks/team_member_repeater/view.css
@@ -1,0 +1,5 @@
+.team-member-list { display:flex; flex-wrap:wrap; gap:20px; }
+.team-member-item { text-align:center; max-width:300px; }
+.team-member-headshot { max-width:100%; height:auto; }
+.team-member-bio { text-align:left; }
+.team-buttons .btn { margin-right:10px; }

--- a/application/blocks/team_member_repeater/view.php
+++ b/application/blocks/team_member_repeater/view.php
@@ -1,0 +1,28 @@
+<?php defined('C5_EXECUTE') or die('Access Denied.'); ?>
+<div class="team-member-repeater-block">
+    <?php if ($headerTitle) { ?>
+        <h2 class="team-header-title"><?= h($headerTitle) ?></h2>
+    <?php } ?>
+    <?php if ($headerDescription) { ?>
+        <div class="team-header-description"><?= LinkAbstractor::translateFrom($headerDescription) ?></div>
+    <?php } ?>
+    <div class="team-buttons">
+        <?php if ($buttonOneText && $buttonOneLink) { ?>
+            <a href="<?= $buttonOneLink ?>" class="btn btn-primary team-button-one"><?= h($buttonOneText) ?></a>
+        <?php } ?>
+        <?php if ($buttonTwoText && $buttonTwoLink) { ?>
+            <a href="<?= $buttonTwoLink ?>" class="btn btn-secondary team-button-two"><?= h($buttonTwoText) ?></a>
+        <?php } ?>
+    </div>
+    <div class="team-member-list">
+        <?php foreach ($rows as $row) { ?>
+            <div class="team-member-item">
+                <?php if ($row['headshotFID']) { $f = File::getByID($row['headshotFID']); if ($f) { ?>
+                    <img class="team-member-headshot" src="<?= $f->getRelativePath() ?>" alt="" />
+                <?php } } ?>
+                <h4 class="team-member-name"><?= h($row['firstName'] . ' ' . $row['lastName']) ?></h4>
+                <div class="team-member-bio"><?= $row['bio'] ?></div>
+            </div>
+        <?php } ?>
+    </div>
+</div>


### PR DESCRIPTION
## Summary
- implement Team Member Repeater custom block
- allows title/description fields, two buttons and repeating member entries
- each entry stores first name, last name, headshot and bio

## Testing
- `composer install` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684087ed0eb8832da4204da7966fad38